### PR TITLE
Fix/invalid json schema

### DIFF
--- a/functions/base64/package.json
+++ b/functions/base64/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@betty-blocks/cli": "^25.27.3",
-    "js-base64": "^3.7.2",
+    "js-base64": "^3.7.2"
   },
   "private": "true"
 }

--- a/functions/import-csv/package.json
+++ b/functions/import-csv/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@betty-blocks/cli": "^25.27.3",
-    "papaparse": "^5.3.2",
+    "papaparse": "^5.3.2"
   },
   "private": "true"
 }


### PR DESCRIPTION
Fixes the invalid comma's found in the two package.json files for the Base64- and Impot CSV step.